### PR TITLE
Add missing meta-annotations on the Command annotation interface + fix command_help

### DIFF
--- a/src/main/java/xyz/devosmium/games/textadventureengine/commands/Command.java
+++ b/src/main/java/xyz/devosmium/games/textadventureengine/commands/Command.java
@@ -1,5 +1,12 @@
 package xyz.devosmium.games.textadventureengine.commands;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
 public @interface Command {
 
   String command();

--- a/src/main/java/xyz/devosmium/games/textadventureengine/commands/EngineCommandRepository.java
+++ b/src/main/java/xyz/devosmium/games/textadventureengine/commands/EngineCommandRepository.java
@@ -1,6 +1,7 @@
 package xyz.devosmium.games.textadventureengine.commands;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import xyz.devosmium.games.textadventureengine.mobiles.Player;
 import xyz.devosmium.games.textadventureengine.util.MessageQueue;
@@ -25,15 +26,14 @@ public class EngineCommandRepository {
 
     MessageQueue.add("");
     for (Method method : methods) {
-      if (!method.isAnnotationPresent(Command.class)) {
-        break;
-      }
-      Command anno = method.getAnnotation(Command.class);
-      String command = anno.command();
-      String description = anno.description();
+      if (method.isAnnotationPresent(Command.class)) {
+    	  Command anno = method.getAnnotation(Command.class);
+          String command = anno.command();
+          String description = anno.description();
 
-      String message = command + ": " + description;
-      MessageQueue.add(message);
+          String message = command + ": " + description;
+          MessageQueue.add(message);
+      }
     }
   }
 }

--- a/src/main/java/xyz/devosmium/games/textadventureengine/commands/EngineCommandRepository.java
+++ b/src/main/java/xyz/devosmium/games/textadventureengine/commands/EngineCommandRepository.java
@@ -1,7 +1,6 @@
 package xyz.devosmium.games.textadventureengine.commands;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 import xyz.devosmium.games.textadventureengine.mobiles.Player;
 import xyz.devosmium.games.textadventureengine.util.MessageQueue;


### PR DESCRIPTION
- If not done, this annotation will never be gotten using reflexion in the
EngineCommandRepository

- Help command stops if finds a method without @command annotation,

- Normally it should ignore other methods (wait, notify, ....) that aren't
annotated with @command, and show only others.